### PR TITLE
:goal_net: Handle invalid token backend 401 error, fixes #57

### DIFF
--- a/src/components/Logout.tsx
+++ b/src/components/Logout.tsx
@@ -1,20 +1,10 @@
-import React, { useContext } from 'react'
-import { useNavigate } from 'react-router-dom'
 import { Button } from 'react-bootstrap'
-import { TokenContext } from '../context/token'
-import { removeTokenLocalStorage } from '../utils/helpers'
+import { useLogout } from '../utils/hooks'
 
 const Logout = (): JSX.Element => {
-  const { setToken } = useContext(TokenContext)
   // TODO: ideally hit the backend to invalidate the token too
-  const navigate = useNavigate()
-  const onLogout = (): void => {
-    removeTokenLocalStorage()
-    setToken(null)
-    navigate('/')
-  }
-
-  const onLogoutClick = (e: React.MouseEvent<HTMLElement>): void => onLogout()
+  const logout = useLogout()
+  const onLogoutClick = (e: React.MouseEvent<HTMLElement>): void => logout()
 
   return (
     <Button type='submit' onClick={onLogoutClick}>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -64,7 +64,12 @@ interface PrescriptionUploadResponse {
   photo_prescription: string
 }
 
+interface ErrorResponse {
+  detail: string
+}
+
 export type {
+  ErrorResponse,
   Patient,
   Prescription,
   PrescriptionUploadResponse,

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -1,4 +1,6 @@
 import { useContext } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { removeTokenLocalStorage } from './helpers'
 import { TokenContext } from '../context/token'
 
 /**
@@ -15,4 +17,14 @@ const useIsLoggedIn = (): boolean|undefined => {
   return tokenValid
 }
 
-export { useIsLoggedIn }
+const useLogout = (): () => void => {
+  const { setToken } = useContext(TokenContext)
+  const navigate = useNavigate()
+  return () => {
+    removeTokenLocalStorage()
+    setToken(null)
+    navigate('/')
+  }
+}
+
+export { useIsLoggedIn, useLogout }


### PR DESCRIPTION
Erases the token from the local storage if the backend returns a 401
with an "Invalid token" message.
Introduces a new `useLogout()` hook that's used in both fetch profile
invalid token error and explicit logout (button click).